### PR TITLE
Add logging for debugging purposes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+/vendor/

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     "require": {
         "php": ">=5.3.0",
         "ext-json": "*",
-        "ext-xml": "*"
+        "ext-xml": "*",
+        "psr/log": "1.0.0"
     },
     "autoload": {
         "psr-4": { "TracRPC\\": "lib/" }

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,61 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "hash": "4cbee95e665c254baadf62de156a56f2",
+    "content-hash": "6fc4881bb4a8497ae422a743ba276362",
+    "packages": [
+        {
+            "name": "psr/log",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/fe0936ee26643249e916849d48e3a51d5f5e278b",
+                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Psr\\Log\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "time": "2012-12-21 11:40:51"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=5.3.0",
+        "ext-json": "*",
+        "ext-xml": "*"
+    },
+    "platform-dev": []
+}


### PR DESCRIPTION
Hey @jakoch - While I was messing around with this today, I ended up adding a logger object (Psr\Log\NullLogger) into the code so I could substitute a real logger, either in production or just while figuring things out.

I figured I'd submit a pull request for you to look at - this isn't perfect by any stretch - I just needed a better way to delve into the code and figure out what was happening.

By default, it's just a NullLogger - the logging just goes nowhere - so it shouldn't be too much of a performance hit.  At runtime, you can chose to substitute any PSR-3 compliant logger, such as Monolog.